### PR TITLE
Add Mantica startup docs and venv setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 r8_token
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 Test repository to be used as a playground for the evaluation of different AI coding agents.
+
+## Environment setup
+
+Use `./setup-venv.sh` to create the `.venv` Python virtual environment and install the packages required by a given experiment. The script is generic and can be used for Mantica as well as future applications that may live in this repository.
+
+## Mantica
+
+Mantica is a small Flask application that transforms captured images using the Replicate API.
+
+### Getting started
+
+1. Run `./setup-venv.sh` (see **Environment setup** above) to create a Python virtual environment and install dependencies.
+2. Activate the environment with `source .venv/bin/activate`.
+3. Place your Replicate API token in a file named `r8_token` in the repository root.
+4. Start the server with `python mantica.py` and open `http://localhost:5000` in your browser.

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+# Activate the environment
+source .venv/bin/activate
+
+# Upgrade pip and install required packages
+pip install --upgrade pip
+pip install flask replicate requests


### PR DESCRIPTION
## Summary
- add `.venv/` to `.gitignore`
- document how to run Mantica in README
- add `setup-venv.sh` to create the virtual environment and install packages
- clarify that the setup script works for any experiment

## Testing
- `python3 -m py_compile mantica.py`
- `./setup-venv.sh` *(fails: Could not find a version that satisfies the requirement flask)*