### PR TITLE
Update image handling and sanitize prompts

### DIFF
--- a/mantica.py
+++ b/mantica.py
@@ -1,6 +1,6 @@
 import os
 import base64
-import tempfile
+import re
 from flask import Flask, render_template, request, jsonify
 
 app = Flask(__name__)
@@ -11,6 +11,17 @@ REPLICATE_TOKEN = None
 if os.path.exists(TOKEN_PATH):
     with open(TOKEN_PATH, 'r') as f:
         REPLICATE_TOKEN = f.read().strip()
+
+# Default negative prompt used for image generation
+NEGATIVE_PROMPT = (
+    "blurry, deformed, low quality, bad anatomy, disfigured, poorly drawn"
+)
+
+# Terms removed from user prompts before sending to the model
+BAN_TERMS = [
+    "nsfw",
+    "nude",
+]
 
 try:
     import replicate
@@ -28,30 +39,38 @@ def transform():
     if replicate is None:
         return jsonify({'error': 'Replicate library not installed'}), 500
     data = request.get_json()
-    img_data = data['image'].split(',')[1]
+    image_data_url = data.get('image', '')
     prompt = data.get('prompt', '')
     strength = float(data.get('strength', 0.73))
 
-    # Decode image data
-    image_bytes = base64.b64decode(img_data)
-    with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp:
-        temp.write(image_bytes)
-        temp_path = temp.name
+    # Remove banned terms from the prompt
+    for term in BAN_TERMS:
+        prompt = re.sub(r'\b' + re.escape(term) + r'\b', '', prompt, flags=re.IGNORECASE)
+    prompt = ' '.join(prompt.split())
 
     client = replicate.Client(api_token=REPLICATE_TOKEN)
 
-    # Example model; may need adjustment
-    model = 'stability-ai/stable-diffusion-img2img'
-    result = client.run(model, input={
-        'image': open(temp_path, 'rb'),
-        'prompt': prompt,
-        'strength': strength,
-    })
+    # Parameters tuned similarly to the PHP version
+    result = client.run(
+        "black-forest-labs/flux-dev",
+        input={
+            "prompt": prompt,
+            "aspect_ratio": "1:1",
+            "image": image_data_url,
+            "prompt_strength": strength,
+            "num_outputs": 1,
+            "num_inference_steps": 28,
+            "guidance": 3.5,
+            "output_format": "png",
+            "output_quality": 100,
+            "negative_prompt": NEGATIVE_PROMPT,
+            "go_fast": True,
+        },
+    )
 
     # result is usually a URL; download image
     output_url = result[0] if isinstance(result, list) else result
     transformed = requests.get(output_url).content
-    os.remove(temp_path)
 
     out_b64 = base64.b64encode(transformed).decode('utf-8')
     return jsonify({'image': 'data:image/png;base64,' + out_b64})


### PR DESCRIPTION
## Summary
- add `BAN_TERMS` and remove them from prompts before calling Replicate
- send the image to Replicate as a data URL instead of a file

## Testing
- `python -m py_compile mantica.py`