### PR TITLE
Adjust overlay animation timing and depth

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,11 +21,11 @@
       display: none;
     }
     @keyframes fadeToBlack {
-      0%, 100% { opacity: 0; }
-      50% { opacity: 0.6; }
+      0%, 100% { opacity: 0.2; }
+      50% { opacity: 0.5; }
     }
     .fade-animation {
-      animation: fadeToBlack 2s infinite;
+      animation: fadeToBlack 3s infinite;
       display: block;
     }
     #controls, #after { position: absolute; bottom: 20px; left: 0; right: 0; display: flex; justify-content: center; gap: 20px; }


### PR DESCRIPTION
## Summary
- tune the fade-to-black animation so it never goes fully transparent
- slow down the animation a bit

## Testing
- `python -m py_compile mantica.py`
