### PR TITLE
Tweak Mantica capture button styling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,7 @@
       right: 0;
       display: flex;
       justify-content: space-between;
+      align-items: center;
       padding: 0 40px;
     }
     #controls button, #after button {
@@ -51,9 +52,9 @@
     }
     #controls #capture {
       background: rgba(128,0,128,0.6);
-      width: clamp(100px, 30vw, 150px);
-      height: clamp(100px, 30vw, 150px);
-      font-size: clamp(30px, 9vw, 48px);
+      width: clamp(60px, 18vw, 96px);
+      height: clamp(60px, 18vw, 96px);
+      font-size: clamp(24px, 7.2vw, 38.4px);
     }
     #title { position: absolute; top: 10px; left: 10px; color: white; }
     @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- make the capture button just 1.2x the size of the others
- align controls' vertical centers so button centers match

## Testing
- `python -m py_compile mantica.py`