### PR TITLE
Add waitress for production mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Test repository to be used as a playground for the evaluation of different AI co
 Mantica is a small Flask application that transforms captured images using the Replicate API.
 
 1. Place your Replicate API token in a file named `r8_token` in the repository root.
-2. Start the server with `python mantica.py` and open `http://localhost:5000` in your browser.
+2. Start the server with `python mantica.py` and open `http://localhost:5000` in your browser. For a production-style deployment, install `waitress` and run `python mantica.py --prod` instead.

--- a/mantica.py
+++ b/mantica.py
@@ -4,7 +4,7 @@
 # Unauthorized copying, distribution, or use of this software in whole or in part
 # is prohibited without the express written permission of the copyright holder.
 #
-# pip install flask replicate requests pillow
+# pip install flask replicate requests pillow waitress
 #
 
 import os
@@ -449,4 +449,12 @@ document.getElementById('save').onclick = () => {
 """
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import sys
+    if '--prod' in sys.argv:
+        try:
+            from waitress import serve
+        except ImportError:
+            raise SystemExit("waitress is required for production mode. Install it with 'pip install waitress'")
+        serve(app, host='0.0.0.0', port=5000)
+    else:
+        app.run(debug=True)

--- a/setup-venv.sh
+++ b/setup-venv.sh
@@ -11,4 +11,4 @@ source .venv/bin/activate
 
 # Upgrade pip and install required packages
 pip install --upgrade pip
-pip install flask replicate requests pillow
+pip install flask replicate requests pillow waitress


### PR DESCRIPTION
## Summary
- add waitress to dependencies
- support `--prod` arg for waitress server
- document new server option
- update setup script to install waitress

## Testing
- `python -m py_compile mantica.py`
- `bash -n setup-venv.sh`
