### PR TITLE
Switch Mantica to config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 .venv/
-r8_token
+config
 logs/

--- a/README.md
+++ b/README.md
@@ -9,5 +9,12 @@ Test repository to be used as a playground for the evaluation of different AI co
 
 Mantica is a small Flask application that transforms captured images using the Replicate API.
 
-1. Place your Replicate API token in a file named `r8_token` in the repository root.
-2. Start the server with `python mantica.py` and open `http://localhost:5000` in your browser. The script uses the Waitress WSGI server.
+1. Create a `config` file in the repository root containing:
+
+   ```
+   r8_token=YOUR_REPLICATE_TOKEN
+   host=0.0.0.0
+   port=8073
+   ```
+
+2. Start the server with `python mantica.py` and open `http://localhost:8073` in your browser. The script uses the Waitress WSGI server.

--- a/config.example
+++ b/config.example
@@ -1,0 +1,3 @@
+r8_token=YOUR_REPLICATE_TOKEN
+host=0.0.0.0
+port=8073

--- a/mantica.py
+++ b/mantica.py
@@ -20,12 +20,29 @@ from waitress import serve
 
 app = Flask(__name__)
 
-# Load Replicate token from file
-TOKEN_PATH = os.path.join(os.path.dirname(__file__), 'r8_token')
+# Load configuration (Replicate token, host and port)
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config')
 REPLICATE_TOKEN = None
-if os.path.exists(TOKEN_PATH):
-    with open(TOKEN_PATH, 'r') as f:
-        REPLICATE_TOKEN = f.read().strip()
+HOST = '0.0.0.0'
+PORT = 8073
+if os.path.exists(CONFIG_PATH):
+    with open(CONFIG_PATH, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            key = key.strip()
+            value = value.strip()
+            if key == 'r8_token':
+                REPLICATE_TOKEN = value
+            elif key == 'host':
+                HOST = value
+            elif key == 'port':
+                try:
+                    PORT = int(value)
+                except ValueError:
+                    pass
 
 # Default negative prompt used for image generation
 NEGATIVE_PROMPT = "nsfw, naked"
@@ -445,4 +462,4 @@ document.getElementById('save').onclick = () => {
 """
 
 if __name__ == '__main__':
-    serve(app, host='0.0.0.0', port=8073)
+    serve(app, host=HOST, port=PORT)


### PR DESCRIPTION
## Summary
- replace `r8_token` with `config` in .gitignore
- document new config format in README
- load Replicate token, host and port from `config`
- adjust server startup to use configured host and port
- provide `config.example` with sample values

## Testing
- `python -m py_compile mantica.py`