### PR TITLE
Enable optional Waitress logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Mantica is a small Flask application that transforms captured images using the R
    r8_token=YOUR_REPLICATE_TOKEN
    host=0.0.0.0
    port=8073
+   logging=false
    ```
 
 2. Start the server with `python mantica.py` and open `http://localhost:8073` in your browser. The script uses the Waitress WSGI server.

--- a/config.example
+++ b/config.example
@@ -1,3 +1,4 @@
 r8_token=YOUR_REPLICATE_TOKEN
 host=0.0.0.0
 port=8073
+logging=false

--- a/mantica.py
+++ b/mantica.py
@@ -12,6 +12,7 @@ import base64
 import re
 import replicate
 import requests
+import logging
 from datetime import datetime
 from io import BytesIO
 from flask import Flask, render_template_string, request, jsonify
@@ -25,6 +26,7 @@ CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config')
 REPLICATE_TOKEN = None
 HOST = '0.0.0.0'
 PORT = 8073
+WAITRESS_LOGGING = False
 if os.path.exists(CONFIG_PATH):
     with open(CONFIG_PATH, 'r') as f:
         for line in f:
@@ -43,6 +45,8 @@ if os.path.exists(CONFIG_PATH):
                     PORT = int(value)
                 except ValueError:
                     pass
+            elif key == 'logging':
+                WAITRESS_LOGGING = value.lower() == 'true'
 
 # Default negative prompt used for image generation
 NEGATIVE_PROMPT = "nsfw, naked"
@@ -462,4 +466,6 @@ document.getElementById('save').onclick = () => {
 """
 
 if __name__ == '__main__':
+    if WAITRESS_LOGGING:
+        logging.basicConfig(level=logging.INFO)
     serve(app, host=HOST, port=PORT)


### PR DESCRIPTION
## Summary
- add `WAITRESS_LOGGING` flag
- read `logging=true` from config
- enable waitress logging when requested
- document the new option in README and example config

## Testing
- `python -m py_compile mantica.py`
- `pytest -q` *(fails: command not found)*