### PR TITLE
Trust X-Forwarded-For via ProxyFix

### DIFF
--- a/mantica.py
+++ b/mantica.py
@@ -16,10 +16,13 @@ import logging
 from datetime import datetime
 from io import BytesIO
 from flask import Flask, render_template, request, jsonify
+from werkzeug.middleware.proxy_fix import ProxyFix
 from PIL import Image, ImageDraw, ImageFont
 from waitress import serve
 
 app = Flask(__name__, template_folder=os.path.dirname(__file__))
+# Use ProxyFix to trust the first IP in the X-Forwarded-For header.
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1)
 
 # Load configuration (Replicate token, host and port)
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config')
@@ -125,17 +128,11 @@ def transform():
             logs_dir = os.path.join(os.path.dirname(__file__), 'logs')
             os.makedirs(logs_dir, exist_ok=True)
             timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
-            # Prefer the client IP from the X-Forwarded-For header if present.
-            # Fall back to the remote address seen by the server. Sanitize the
-            # IP so it is safe for use in filenames by replacing dots and
-            # colons (to support both IPv4 and IPv6 addresses).
-            fwd_header = request.headers.get('X-Forwarded-For', '')
-            if fwd_header:
-                # Use only the first IP in the list, which represents the
-                # original client when behind proxies.
-                ip = fwd_header.split(',')[0].strip()
-            else:
-                ip = request.remote_addr or 'unknown'
+            # The ProxyFix middleware has already resolved the client IP from
+            # the X-Forwarded-For header. Sanitize it so it is safe for use in
+            # filenames by replacing dots and colons (to support both IPv4 and
+            # IPv6 addresses).
+            ip = request.remote_addr or 'unknown'
             ip = ip.replace(':', '_').replace('.', '_')
             filename = f"{timestamp}-{ip}.jpg"
 


### PR DESCRIPTION
## Summary
- apply `ProxyFix` middleware to trust `X-Forwarded-For`
- rely on `request.remote_addr` for logging after `ProxyFix`

## Testing
- `python -m py_compile mantica.py`