### PR TITLE
Add PWA features

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,26 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="theme-color" content="#000000">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" type="image/png" href="favicon.png">
+  <link rel="apple-touch-icon" href="favicon.png">
   <title>Mantica</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <style>
-    body, html { margin: 0; height: 100%; font-family: Arial, sans-serif; overflow:hidden; touch-action:none; overscroll-behavior: none; }
+    *, *::before, *::after { -webkit-tap-highlight-color: transparent; }
+    body, html {
+      margin: 0;
+      height: 100%;
+      font-family: Arial, sans-serif;
+      overflow: hidden;
+      touch-action: none;
+      overscroll-behavior: none;
+      -webkit-user-select: none;
+      user-select: none;
+      -webkit-touch-callout: none;
+    }
     #camera { position: relative; width: 100%; height: 100%; }
     video, img { width: 100%; height: 100%; object-fit: cover; }
     .mirror { transform: scaleX(-1); }
@@ -306,6 +322,14 @@ document.getElementById('save').onclick = async () => {
   a.click();
   URL.revokeObjectURL(a.href);
 };
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('service-worker.js').catch(() => {});
+}
+
+document.addEventListener('contextmenu', e => e.preventDefault());
+document.addEventListener('touchmove', e => e.preventDefault(), {passive: false});
+document.addEventListener('gesturestart', e => e.preventDefault());
 </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Mantica",
+  "short_name": "Mantica",
+  "icons": [
+    {
+      "src": "favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000"
+}

--- a/mantica.py
+++ b/mantica.py
@@ -15,7 +15,7 @@ import requests
 import logging
 from datetime import datetime
 from io import BytesIO
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, send_from_directory
 from PIL import Image, ImageDraw, ImageFont
 from waitress import serve
 
@@ -57,6 +57,18 @@ BAN_TERMS = ["nude", "naked", "blood", "dead", "nsfw", "nude"]
 @app.route('/')
 def index():
     return render_template('index.html')
+
+@app.route('/manifest.json')
+def manifest():
+    return send_from_directory(os.path.dirname(__file__), 'manifest.json')
+
+@app.route('/service-worker.js')
+def service_worker():
+    return send_from_directory(os.path.dirname(__file__), 'service-worker.js')
+
+@app.route('/favicon.png')
+def favicon():
+    return send_from_directory(os.path.dirname(__file__), 'favicon.png')
 
 @app.route('/transform', methods=['POST'])
 def transform():

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const cacheName = 'mantica-cache-v1';
+const assets = [
+  './',
+  'index.html',
+  'favicon.png',
+  'manifest.json'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(cacheName).then(cache => cache.addAll(assets))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- support installation as a PWA
- add manifest and service worker
- disable selection and scrolling for a native feel
- serve favicon and manifest from Flask

## Testing
- `python -m py_compile mantica.py`