### PR TITLE
Fix strength label layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,11 @@
     #close {
       position: static;
     }
+    #strengthVal {
+      width: 4ch;
+      display: inline-block;
+      text-align: right;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- make the strength label in the settings modal a fixed width so the slider length remains constant

## Testing
- `python -m py_compile mantica.py`
