### PR TITLE
Add Enter key blur in prompt settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,13 @@ let promptCaption = document.getElementById('promptCaption');
 
 promptInput.value = localStorage.getItem('mantica_prompt') || '';
 
+promptInput.addEventListener('keydown', e => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    promptInput.blur();
+  }
+});
+
 function isMobile() {
   return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }


### PR DESCRIPTION
## Summary
- dismiss mobile keyboards when hitting enter on the prompt field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68468f9443b8832588fe4a2fcbde5a2c